### PR TITLE
Implement cancellation forwarding for previously queued operations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
-  - hhvm
+  - hhvm # ignore errors, see below
 
 # lock distro so new future defaults will not break the build
 dist: trusty
@@ -17,6 +17,8 @@ matrix:
   include:
     - php: 5.3
       dist: precise
+  allow_failures:
+    - php: hhvm
 
 sudo: false
 


### PR DESCRIPTION
While working on an implementation for #6, I noticed that cancellation of operations that were previously queued and are now pending is not supported. Cancellation of operations that have been started instantly and are still pending and those that are currently queued for future execution already worked as expected.

This will eventually also be addressed upstream via https://github.com/reactphp/promise/pull/99, but it's currently not decided when this version will be tagged.