### PR TITLE
Add all() helper to await successful fulfillment of all operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ much any API that already uses Promises.
     * [Promises](#promises)
     * [Cancellation](#cancellation)
     * [Timeout](#timeout)
+    * [all()](#all)
     * [Blocking](#blocking)
 * [Install](#install)
 * [Tests](#tests)
@@ -256,6 +257,81 @@ $promise = Timer\timeout($q($url), 2.0, $loop);
 Please refer to [react/promise-timer](https://github.com/reactphp/promise-timer)
 for more details.
 
+#### all()
+
+The static `all(int $concurrency, array $jobs, callable $handler): PromiseInterface<mixed[]>` method can be used to
+concurrently process all given jobs through the given `$handler`.
+
+This is a convenience method which uses the `Queue` internally to
+schedule all jobs while limiting concurrency to ensure no more than
+`$concurrency` jobs ever run at once. It will return a promise which
+resolves with the results of all jobs on success.
+
+```php
+$loop = React\EventLoop\Factory::create();
+$browser = new Clue\React\Buzz\Browser($loop);
+
+$promise = Queue:all(3, $urls, function ($url) use ($browser) {
+    return $browser->get($url);
+});
+
+$promise->then(function (array $responses) {
+    echo 'All ' . count($responses) . ' successful!' . PHP_EOL;
+});
+```
+
+If either of the jobs fail, it will reject the resulting promise and will
+try to cancel all outstanding jobs. Similarly, calling `cancel()` on the
+resulting promise will try to cancel all outstanding jobs. See
+[promises](#promises) and [cancellation](#cancellation) for details.
+
+The `$concurrency` parameter sets a new soft limit for the maximum number
+of jobs to handle concurrently. Finding a good concurrency limit depends
+on your particular use case. It's common to limit concurrency to a rather
+small value, as doing more than a dozen of things at once may easily
+overwhelm the receiving side. Using a `1` value will ensure that all jobs
+are processed one after another, effectively creating a "waterfall" of
+jobs. Using a value less than 1 will reject with an
+`InvalidArgumentException` without processing any jobs.
+
+```php
+// handle up to 10 jobs concurrently
+$promise = Queue:all(10, $jobs, $handler);
+```
+
+```php
+// handle each job after another without concurrency (waterfall)
+$promise = Queue:all(1, $jobs, $handler);
+```
+
+The `$jobs` parameter must be an array with all jobs to process. Each
+value in this array will be passed to the `$handler` to start one job.
+The array keys will be preserved in the resulting array, while the array
+values will be replaced with the job results as returned by the
+`$handler`. If this array is empty, this method will resolve with an
+empty array without processing any jobs.
+
+The `$handler` parameter must be a valid callable that accepts your job
+parameters, invokes the appropriate operation and returns a Promise as a
+placeholder for its future result. If the given argument is not a valid
+callable, this method will reject with an `InvalidArgumentExceptionn`
+without processing any jobs.
+
+```php
+// using a Closure as handler is usually recommended
+$promise = Queue::all(10, $jobs, function ($url) use ($browser) {
+    return $browser->get($url);
+});
+```
+
+```php
+// accepts any callable, so PHP's array notation is also supported
+$promise = Queue:all(10, $jobs, array($browser, 'get'));
+```
+
+> Keep in mind that returning an array of response messages means that
+  the whole response body has to be kept in memory.
+
 #### Blocking
 
 As stated above, this library provides you a powerful, async API by default.
@@ -272,18 +348,12 @@ use Clue\React\Block;
 $loop = React\EventLoop\Factory::create();
 $browser = new Clue\React\Buzz\Browser($loop);
 
-$q = new Queue(10, null, function ($url) use ($browser) {
+$promise = Queue:all(3, $urls, function ($url) use ($browser) {
     return $browser->get($url);
 });
 
-$promises = array(
-    $q('http://example.com/'),
-    $q('http://www.example.org/'),
-    $q('http://example.net/'),
-);
-
 try {
-    $responses = Block\awaitAll($promises, $loop);
+    $responses = Block\await($promise, $loop);
     // responses successfully received
 } catch (Exception $e) {
     // an error occured while performing the requests
@@ -306,16 +376,11 @@ function download(array $uris)
     $loop = React\EventLoop\Factory::create();
     $browser = new Clue\React\Buzz\Browser($loop);
 
-    $q = new Queue(10, null, function ($uri) use ($browser) {
+    $promise = Queue::all(3, $uris, function ($uri) use ($browser) {
         return $browser->get($uri);
     });
 
-    $promises = array();
-    foreach ($uris as $uri) {
-        $promises[$uri] = $q($uri);
-    }
-
-    return Clue\React\Block\awaitAll($promises, $loop);
+    return Clue\React\Block\await($promise, $loop);
 }
 ```
 

--- a/examples/02-http-all.php
+++ b/examples/02-http-all.php
@@ -1,0 +1,42 @@
+<?php
+
+use Clue\React\Buzz\Browser;
+use Clue\React\Mq\Queue;
+use Psr\Http\Message\ResponseInterface;
+use React\EventLoop\Factory;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+// list of all URLs you want to download
+// this list may potentially contain hundreds or thousands of entries
+$urls = array(
+    'http://www.github.com/',
+    'http://www.yahoo.com/',
+    'http://www.bing.com/',
+    'http://www.google.com/',
+    //'http://httpbin.org/delay/2',
+);
+
+$loop = Factory::create();
+$browser = new Browser($loop);
+
+// each job should use the browser to GET a certain URL
+// limit number of concurrent jobs here to avoid using excessive network resources
+$promise = Queue::all(3, array_combine($urls, $urls), function ($url) use ($browser) {
+    return $browser->get($url);
+});
+
+$promise->then(
+    function ($responses) {
+        /* @var $responses ResponseInterface[] */
+        echo 'All URLs succeeded!' . PHP_EOL;
+        foreach ($responses as $url => $response) {
+            echo $url . ' has ' . $response->getBody()->getSize() . ' bytes' . PHP_EOL;
+        }
+    },
+    function ($e) {
+        echo 'An error occured: ' . $e->getMessage() . PHP_EOL;
+    }
+);
+
+$loop->run();

--- a/tests/QueueAllTest.php
+++ b/tests/QueueAllTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Clue\Tests\React\Mq;
+
+use Clue\React\Mq\Queue;
+use React\Promise\Promise;
+use React\Promise\Deferred;
+
+class QueueAllTest extends TestCase
+{
+    public function testAllRejectsIfConcurrencyIsInvalid()
+    {
+        Queue::all(0, array(), function ($arg) {
+            return \React\Promise\resolve($arg);
+        })->then(null, $this->expectCallableOnce());
+    }
+
+    public function testAllRejectsIfHandlerIsInvalid()
+    {
+        Queue::all(1, array(), 'foobar')->then(null, $this->expectCallableOnce());
+    }
+
+    public function testWillResolveWithtEmptyArrayWithoutInvokingHandlerWhenJobsAreEmpty()
+    {
+        $promise = Queue::all(1, array(), $this->expectCallableNever());
+
+        $promise->then($this->expectCallableOnceWith(array()));
+    }
+
+    public function testWillResolveWithSingleValueIfHandlerResolves()
+    {
+        $promise = Queue::all(1, array(1), function ($arg) {
+            return \React\Promise\resolve($arg);
+        });
+
+        $promise->then($this->expectCallableOnceWith(array(1)));
+    }
+
+    public function testWillResolveWithAllValuesIfHandlerResolves()
+    {
+        $promise = Queue::all(1, array(1, 2), function ($arg) {
+            return \React\Promise\resolve($arg);
+        });
+
+        $promise->then($this->expectCallableOnceWith(array(1, 2)));
+    }
+
+    public function testWillRejectIfSingleRejects()
+    {
+        $promise = Queue::all(1, array(1), function () {
+            return \React\Promise\reject(new \RuntimeException());
+        });
+
+        $promise->then(null, $this->expectCallableOnce());
+    }
+
+    public function testWillRejectIfMoreHandlersReject()
+    {
+        $promise = Queue::all(1, array(1, 2), function () {
+            return \React\Promise\reject(new \RuntimeException());
+        });
+
+        $promise->then(null, $this->expectCallableOnce());
+    }
+
+    public function testCancelResultingPromiseWillCancelPendingOperation()
+    {
+        $pending = new Promise(function () { }, $this->expectCallableOnce());
+
+        $promise = Queue::all(1, array(1), function () use ($pending) {
+            return $pending;
+        });
+
+        $promise->cancel();
+    }
+
+    public function testPendingOperationWillBeCancelledIfOneOperationRejects22222222222()
+    {
+        $first = new Deferred();
+        $second = new Promise(function () { }, $this->expectCallableOnce());
+
+        $promise = Queue::all(1, array($first->promise(), $second), function ($promise) {
+            return $promise;
+        });
+
+        $first->reject(new \RuntimeException());
+
+        $promise->then(null, $this->expectCallableOnce());
+    }
+
+    public function testPendingOperationWillBeCancelledIfOneOperationRejects()
+    {
+        $first = new Deferred();
+        $second = new Promise(function () { }, $this->expectCallableOnce());
+
+        $promise = Queue::all(2, array($first->promise(), $second), function ($promise) {
+            return $promise;
+        });
+
+        $first->reject(new \RuntimeException());
+
+        $promise->then(null, $this->expectCallableOnce());
+    }
+
+    public function testQueuedOperationsWillStartAndCancelOneIfOneOperationRejects()
+    {
+        $first = new Deferred();
+        $second = new Promise(function () { }, function () {
+            throw new \RuntimeException();
+        });
+        $third = new Promise(function () { }, $this->expectCallableOnce());
+        $fourth = new Promise(function () { }, $this->expectCallableNever());
+
+        $started = 0;
+        $promise = Queue::all(2, array($first->promise(), $second, $third, $fourth), function ($promise) use (&$started) {
+            ++$started;
+            return $promise;
+        });
+
+        $first->reject(new \RuntimeException());
+
+        $this->assertEquals(3, $started);
+    }
+}


### PR DESCRIPTION
A common use case for this queue is to ensure all jobs are successfully fulfilled and to cancel all outstanding jobs if even a single one fails. This PR add a simple `all()` API which ensures that all jobs MUST be fulfilled successfully and will otherwise ensure that all other jobs should be cancelled.

Resolves / closes #6 
Builds on top of #7